### PR TITLE
Move phone-related configuration from 'mofd.mk' into 'mofd_phone.mk'

### DIFF
--- a/mofd.mk
+++ b/mofd.mk
@@ -14,12 +14,6 @@
 # limitations under the License.
 #
 
-# call dalvik heap config
-$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
-
-# call hwui memory config
-$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-2048-hwui-memory.mk)
-
 DEVICE_PACKAGE_OVERLAYS := \
     device/asus/mofd-common/overlay
 
@@ -83,7 +77,7 @@ PRODUCT_COPY_FILES += \
 
 # Doze
 PRODUCT_PACKAGES += \
-   ZenfoneDoze
+    ZenfoneDoze
 
 # Factory reset protection
 ADDITIONAL_DEFAULT_PROPERTIES += \
@@ -191,13 +185,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.mofd_v1
 
-# Radio
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.ril.status.polling.enable=0 \
-    rild.libpath=/system/lib/librapid-ril-core.so \
-    ro.telephony.default_network=9,1 \
-    ro.ril.telephony.mqanelements=5
-
 # Ramdisk
 PRODUCT_PACKAGES += \
     config_init.sh \
@@ -212,9 +199,7 @@ PRODUCT_PACKAGES += \
     init.diag.rc \
     init.gps.rc \
     init.logtool.rc \
-    init.modem.rc \
     init.mofd_v1.rc \
-    init.nfc.rc \
     init.platform.usb.rc \
     init.power.mofd_v1.rc \
     init.recovery.mofd_v1.rc \

--- a/mofd_phone.mk
+++ b/mofd_phone.mk
@@ -1,0 +1,39 @@
+#
+# Copyright 2013 The Android Open-Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+$(call inherit-product, mofd.mk)
+
+# call dalvik heap config
+$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
+
+# call hwui memory config
+$(call inherit-product-if-exists, frameworks/native/build/phone-xxhdpi-2048-hwui-memory.mk)
+
+# Radio
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.ril.status.polling.enable=0 \
+    rild.libpath=/system/lib/librapid-ril-core.so \
+    ro.telephony.default_network=9,1 \
+    ro.ril.telephony.mqanelements=5
+
+# Ramdisk
+PRODUCT_PACKAGES += \
+    init.modem.rc \
+    init.nfc.rc
+
+# Permissions
+PRODUCT_COPY_FILES += \
+    frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml

--- a/mofd_tablet.mk
+++ b/mofd_tablet.mk
@@ -1,0 +1,1 @@
+$(call inherit-product, mofd.mk)


### PR DESCRIPTION
Create 'mofd_tablet.mk' too, as some of the stuff needed by phones are not necessary for ASUS Moorefield tablets.

This would obviously break device trees not updated to support this.
